### PR TITLE
Fix setunitdata UMOB_ATKMIN,UMOB_ATKMAX

### DIFF
--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -206,7 +206,7 @@ db_path: db
 // NOTE: Requires client 2011-03-09aragexeRE or newer.
 // A window is opened before you can select your character and you will have to enter a pincode by using only your mouse.
 // Default: yes
-pincode_enabled: yes
+pincode_enabled: no
 
 // How often does a user have to change his pincode?
 // 0: never (default)

--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -206,7 +206,7 @@ db_path: db
 // NOTE: Requires client 2011-03-09aragexeRE or newer.
 // A window is opened before you can select your character and you will have to enter a pincode by using only your mouse.
 // Default: yes
-pincode_enabled: no
+pincode_enabled: yes
 
 // How often does a user have to change his pincode?
 // 0: never (default)

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12637,7 +12637,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 	}
 
-	if (current_equip_combo_pos && tick == INFINITE_TICK) {
+	if (sd && current_equip_combo_pos > 0 && tick == INFINITE_TICK) {
 		ShowWarning("sc_start: Item combo of item #%u contains an INFINITE_TICK duration. Skipping bonus.\n", sd->inventory_data[pc_checkequip(sd, current_equip_combo_pos)]->nameid);
 		return 0;
 	}

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5736,6 +5736,8 @@ void status_calc_bl_main(struct block_list *bl, /*enum scb_flag*/int flag)
 			status->watk2 = status_calc_watk(bl, sc, b_status->watk2);
 		}
 		else status->watk = status_calc_watk(bl, sc, b_status->watk);
+		status->rhw.atk = status_calc_watk(bl, sc, b_status->rhw.atk);
+        status->rhw.atk2 = status_calc_watk(bl, sc, b_status->rhw.atk2);
 #endif
 	}
 
@@ -5942,6 +5944,8 @@ void status_calc_bl_main(struct block_list *bl, /*enum scb_flag*/int flag)
 		 * MATK = (sMATK + wMATK + eMATK) * Multiplicative Modifiers
 		 **/
 		int lv = status_get_lv(bl);
+		// We are using status instead of base_status to include INT changes, but base MATK isn't yet in status so copy it.
+        status->rhw.matk = b_status->rhw.matk;
 		status->matk_min = status_base_matk_min(bl, status, lv);
 		status->matk_max = status_base_matk_max(bl, status, lv);
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: setunitdata UMOB_ATKMIN,UMOB_ATKMAX ไม่สามารถใช้ได้

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: ปรับให้ค่า UMOB_ATKMIN,UMOB_ATKMAX สามารถใช้ได้
เพื่อ บังหมบนัมเบอร์วัน `Striker#0025`

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
